### PR TITLE
Windows cmd.exe and powershell.exe fix.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -447,7 +447,8 @@ if (command == 'create') {
       fs.writeFileSync(baasilConfigFilePath, JSON.stringify(baasilConfig, null, 2));
 
       execSync(`docker build -t ${dockerConfig.imageName} .`, {stdio: 'inherit'});
-      execSync(`${dockerLoginCommand}; docker push ${dockerConfig.imageName}`, {stdio: 'inherit'});
+      execSync(`${dockerLoginCommand}`, {stdio: 'inherit'});
+      execSync(`docker push ${dockerConfig.imageName}`, {stdio: 'inherit'});
 
       var kubernetesDirPath = appPath + '/kubernetes';
 


### PR DESCRIPTION
When child_process chooses cmd.exe as it's shell, the correct chaining of commands is '&', but for powershell it's ';'. This caused an error in the deploy command. So, instead of worrying about which shell we're in, we just split the commands into separate invocations.

Problem solved.